### PR TITLE
docs(DVLSForLinux): fix one-liner install command

### DIFF
--- a/DVLSForLinux/README.md
+++ b/DVLSForLinux/README.md
@@ -44,7 +44,7 @@ You have two ways to run the script, either interactive with prompts, or non-int
 Copy and run this bash one-liner in a terminal:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/Devolutions/ScriptLibrary/refs/heads/main/DVLSForLinux/install-dvls.sh" | bash
+bash <(curl --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/Devolutions/ScriptLibrary/refs/heads/main/DVLSForLinux/install-dvls.sh")
 ```
 
 ## Non-Interactive Install Parameters


### PR DESCRIPTION
We can’t pipe using `|` because our script is also reading user input from stdin.
When using `|`, we modify stdin to be the stdout of the command coming before it.
Instead, we fully read the file in memory, and give the result to `bash` using the `<` operator.
This is performed in-line using parenthesis `(` `)` bash syntax to group statements together.
This doesn’t capture stdin, and allow the user to type as usual.

Before:
![image](https://github.com/user-attachments/assets/858f8655-56b8-497e-bccb-fd63649dfd1c)

After:
![image](https://github.com/user-attachments/assets/95a6d0f6-1366-4507-a0ea-21c55033431f)